### PR TITLE
chore: preserve npm semver ranges and auto-merge action digest pins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1060,9 +1060,9 @@
       }
     },
     "node_modules/@vue/eslint-config-typescript": {
-      "version": "14.8.0",
-      "resolved": "https://registry.npmjs.org/@vue/eslint-config-typescript/-/eslint-config-typescript-14.8.0.tgz",
-      "integrity": "sha512-yIquzhXH7ZsrwSSm+rYvoGCRY6wcuF4qBi76e0l7hHLq7YU0f9aC+RcR5fL+XJNfmBZxgX5cVl4sppt4x7ZCBg==",
+      "version": "14.9.0",
+      "resolved": "https://registry.npmjs.org/@vue/eslint-config-typescript/-/eslint-config-typescript-14.9.0.tgz",
+      "integrity": "sha512-E3j9hDlfVf10F30MRcLTPY2IIhWIx1nsvkVukk14kTcuA+oBVot9zsP1hzsO+PAMDxV3Fd9FimBJtUBNBL5KFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1070,6 +1070,9 @@
         "fast-glob": "^3.3.3",
         "typescript-eslint": "^8.60.0",
         "vue-eslint-parser": "^10.4.0"
+      },
+      "bin": {
+        "vue-eslint-config-typescript": "dist/bin.js"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/renovate.json5
+++ b/renovate.json5
@@ -11,6 +11,9 @@
     ":semanticCommits",
     ":semanticCommitTypeAll(chore)",
     ":semanticCommitScope(deps)",
+    // Keep npm semver ranges (the committed lockfile gives reproducibility); overrides
+    // best-practices dev-dependency pinning. Action digest pinning is unaffected.
+    ":preserveSemverRanges",
   ],
   timezone: "Asia/Tokyo",
   schedule: ["before 9am on monday"],
@@ -26,7 +29,7 @@
   packageRules: [
     {
       description: "Auto-merge non-major updates once CI passes",
-      matchUpdateTypes: ["minor", "patch", "pin", "digest"],
+      matchUpdateTypes: ["minor", "patch", "pin", "pinDigest", "digest"],
       automerge: true,
     },
     {


### PR DESCRIPTION
## Summary

Refine the shared Renovate policy after onboarding feedback:

- **Add `:preserveSemverRanges`** — keep npm dependencies on their semver ranges instead of pinning them. Reproducibility is already guaranteed by the committed lockfile, so pinning `package.json` only adds PR churn. This removes the noisy, identically-titled "pin dependencies" PRs for npm.
- **Add `pinDigest` to the auto-merge update types** — the one-time GitHub Action digest pin (tag → SHA) now auto-merges like other low-risk updates.

GitHub Action digest pinning (supply-chain safety from `config:best-practices`) is governed by `pinDigests` and is **unaffected** by `:preserveSemverRanges`; it stays on.

## Validation

- `renovate-config-validator` (v43) passes.

## Note

Already-merged one-time pin PRs are intentionally left as-is: `main` has advanced since they merged, so reverting would risk version downgrades and lockfile inconsistencies. `:preserveSemverRanges` stops further pinning going forward.
