### PR TITLE
ci: limit push trigger to main to stop duplicate runs

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -2,7 +2,9 @@ name: Browser Tests
 
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   test:

--- a/.github/workflows/npm-ci.yml
+++ b/.github/workflows/npm-ci.yml
@@ -2,6 +2,7 @@ name: Node.js CI
 
 on:
   push:
+    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

Restrict the `push` trigger of both CI workflows to `main`. This unblocks every open dependency update pull request.

## Problem

`npm-ci.yml` and `browser-tests.yml` both trigger on `push` with no branch
filter while also triggering on `pull_request`. Every pull request therefore
ran the full CI twice on the same commit.

For `npm-ci.yml` this was not merely wasteful. Its concurrency group is:

```yaml
group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
cancel-in-progress: true
```

`github.head_ref` (pull_request) and `github.ref_name` (push) resolve to the
same branch name, so both runs share one group and the later `pull_request`
run cancels the `push` run. The `build-summary` job runs under `if: always()`
and treats a cancelled build as a failure:

```
build-summary  One or more build jobs failed or were cancelled.
##[error]Process completed with exit code 1.
```

Because `build-summary` is a required status check, the cancelled run posted a
failing check onto the very commit the `pull_request` run had marked green.

Observed on `renovate/pnpm-11.x` at `f5644c5`, where the same commit carries
both results:

| Check | push run (cancelled) | pull_request run |
| --- | --- | --- |
| `build (22.x)` | cancelled | success |
| `build (24.x)` | cancelled | success |
| `build-summary` | **failure** | success |

All seven open dependency update pull requests were blocked this way.

## Changes

### Fixed

- `.github/workflows/npm-ci.yml`: `on.push` limited to `main`
- `.github/workflows/browser-tests.yml`: `on.push` and `on.pull_request` limited to `main`

`browser-tests.yml` has no concurrency group, so it only wasted a duplicate
run rather than failing. It is corrected here for consistency.

## Effect

- Six of the seven open dependency update pull requests should turn green
- `renovate/typescript-7.x` (#637) stays red for an unrelated reason: `vue-tsc` cannot run under TypeScript 7, which removed `./lib/tsc` from its package exports
- CI minutes per pull request are halved

## Test Plan

- [x] Both files parse as valid YAML and resolve to `{push: {branches: [main]}, pull_request: {branches: [main]}}`
- [ ] CI on this pull request produces exactly one `Node.js CI` run and one `Browser Tests` run